### PR TITLE
fix build on openbsd; use all tests to detect n cores

### DIFF
--- a/R/nmf.R
+++ b/R/nmf.R
@@ -1468,7 +1468,7 @@ function(x, rank, method
 								," [version ", getDoParVersion(),"]")
 				# show number of processes
 				if( getDoParWorkers() == 1 ) message("Mode: sequential [foreach:",getDoParName(),"]")
-				else message("Mode: parallel ", str_c("(", getDoParWorkers(), '/', parallel::detectCores()," core(s))"))
+				else message("Mode: parallel ", str_c("(", getDoParWorkers(), '/', parallel::detectCores(all.tests=TRUE)," core(s))"))
 			}
 			
 			# check shared memory capability

--- a/R/options.R
+++ b/R/options.R
@@ -78,7 +78,7 @@ NULL
 	, gc=50
 	# define default parallel backend 
 	, parallel.backend= option_symlink('pbackend') # for backward compatibility
-	, pbackend= if( parallel::detectCores() > 1 ) 'par' else 'seq'
+	, pbackend= if( parallel::detectCores(all.tests=TRUE) > 1 ) 'par' else 'seq'
 	# toogle verbosity
 	, verbose=FALSE
 	# toogle debug mode

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -16,7 +16,7 @@ NULL
 # specified by the user
 getMaxCores <- function(limit=TRUE){
 	#ceiling(parallel::detectCores()/2)
-	nt <- n <- parallel::detectCores()
+	nt <- n <- parallel::detectCores(all.tests=TRUE)
 	# limit to number of cores specified in options if asked for
 	if( limit ){
 		if( !is.null(nc <- getOption('cores')) ) n <- nc # global option

--- a/inst/tests/runit.parallel.r
+++ b/inst/tests/runit.parallel.r
@@ -266,7 +266,7 @@ test.nmf <- function(){
 	
 	.check('SEQ', .pbackend='SEQ')
 	# Multicore
-	if( parallel::detectCores() > 1 ) 
+	if( parallel::detectCores(all.tests=TRUE) > 1 ) 
 		.check('P2', .options='P2')
 	
 	# SNOW-type from char spec


### PR DESCRIPTION
Hello,

Was just tracking down a build error on OpenBSD, and found that parallel::detectCores() returns NA on OpenBSD unless the "all.tests" option is set, which in turn breaks the build. Adding this option appears to fix the problem by returning the correct number of cores. Don't anticipate this should cause problems on other platforms, though it may potentially take longer to run all the tests on some platforms (returns instantly here).