### PR TITLE
Adds support for viridis color palettes in aheatmap

### DIFF
--- a/R/colorcode.R
+++ b/R/colorcode.R
@@ -59,6 +59,11 @@ ccPalette <- function(x, n=NA, verbose=FALSE){
 			if( require.quiet('RColorBrewer') && x %in% rownames(brewer.pal.info) ){
 				if( verbose ) message("Load and generate ramp from RColorBrewer colour palette '", x, "'")			
 				x <- brewer.pal(brewer.pal.info[x, 'maxcolors'], x)
+            }else if( require.quiet('RColorBrewer') && x %in% c('viridis', 'inferno', 'plasma', 'magma') ) {
+				if( verbose ) message("Load and generate ramp from viridis colour palette '", x, "'")			
+                mapping <- list('viridis' = viridis::viridis, 'inferno' = viridis::inferno,
+                                'magma'   = viridis::magma,   'plasma'  = viridis::plasma)
+                x <- mapping[[x]](1E3) # create a viridis palette with 1000 color values
 			}else{
 				cpal <- c('RdYlBu2', 'rainbow', 'heat', 'topo', 'terrain', 'cm', 'gray', 'grey')
 				i <- pmatch(x, cpal)				

--- a/vignettes/aheatmaps.Rnw
+++ b/vignettes/aheatmaps.Rnw
@@ -120,12 +120,12 @@ strictly impossible with base heatmaps.
 \item Customisation: clustering methods, annotations, colours and legend can all 
 be customised, even separately for rows and columns;
 \item Convenient interface: many arguments provide multiple ways of 
-specifying their value(s), which speeds up developping/writing and reduce the 
+specifying their value(s), which speeds up developing/writing and reduce the 
 amount of code required to generate customised plots (e.g. see
 \cref{sec:colour_spec}).
 \item Aesthetics: the heatmaps look globally cleaner, the image and text components 
 are by default well proportioned relatively to each other, and all fit within 
-the graphic device -- if not set to an unresonnably small size.
+the graphic device -- if not set to an unreasonably small size.
 \end{itemize}
 
 \section{Preliminaries}
@@ -139,7 +139,7 @@ with the following commands:
 
 <<install, eval = FALSE>>=
 # latest stable
-intall.pacakges('NMF')
+install.packages('NMF')
 # development version
 devtools::install_github('NMF', 'renozao', 'devel')
 @


### PR DESCRIPTION
Minor patch to enable `aheatmap` to support [viridis](https://cran.r-project.org/web/packages/viridis/vignettes/intro-to-viridis.html) color palettes.

Also fixed a couple minor typos in the docs along the way.