### PR TITLE
Fix: Cast from matrix to avoid warning in nndsvd

### DIFF
--- a/R/seed-nndsvd.R
+++ b/R/seed-nndsvd.R
@@ -83,7 +83,7 @@ NULL
 		n_vvp = .norm(vvp) ;
 		n_uun = .norm(uun) ;
 		n_vvn = .norm(vvn) ;
-		termp = n_uup %*% n_vvp; termn = n_uun %*% n_vvn;
+		termp = c(n_uup %*% n_vvp); termn = c(n_uun %*% n_vvn);
 		if (termp >= termn){
 			W[,i] = sqrt(S[i] * termp) * uup / n_uup; 
 			H[i,] = sqrt(S[i] * termp) * vvp / n_vvp;


### PR DESCRIPTION
Minor mods to avoid warning messages like:

``` r
## Warning in sqrt(S[i] * termn) * uun: Recycling array of length 1 in array-vector arithmetic is deprecated.
##   Use c() or as.vector() instead.
```

Sending PR to trigger travis checks